### PR TITLE
REL1_38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,37 @@
-#v2.0.2
+# Change log
+
+## v3.0.0
+
+* Make it fully compatible with MediaWiki 1.38 - deal with all deprecated features:
+  * Use `RequestContext::getMain()->getUser()` instead of `$wgUser`,
+  * Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
+  * Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
+  * Use `MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename)` instead of `wfFindFile($filename)`.
+* Tidy up rhe code and remove unused function `embedObject()` (note the `embed()` function does this by default).
+* Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@gmail.com>
+
+## v2.0.2
+
 * Updated extension.json to support MediaWiki 1.30+.
 
-#v2.0.1
+## v2.0.1
+
 * Switched over to iframes to support newer browsers.
 
-#v2.0.0
+## v2.0.0
+
 * Converted to extension registration.
 * Forcing a max-width: 100%; on the object container.
 
-#v1.1.2
+## v1.1.2
+
 * Added page parameter.
 
-#v1.1.1
+## v1.1.1
+
 * German Translations provided by kghbln <kontakt@wikihoster.net>
 
-#v1.1
+## v1.1
+
 * Fix PHP notices being thrown for some parameters.
 * Missing language string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   * Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename)` instead of `wfFindFile($filename)`.
-* Tidy up rhe code and remove unused function `embedObject()` (note the `embed()` function does this by default).
+* Tidy up the code and remove unused function `embedObject()` (note the `embed()` function does this by default).
 * Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@gmail.com>
 
 ## v2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
   * Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
   * Use `MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename)` instead of `wfFindFile($filename)`.
-* Tidy up the code and remove unused function `embedObject()` (note the `embed()` function does this by default).
+* Tidy up the code and remove the unused function `embedObject()` - note the `embed()` function does this when `$iframe=true`.
+* According to a filter applied in [`ve.init.mw.ArticleTargetSaver.js`](https://github.com/wikimedia/mediawiki-extensions-VisualEditor/blob/d9e56ef69ac6938417b558dcf1a7f63e8048256d/modules/ve-mw/preinit/ve.init.mw.ArticleTargetSaver.js#L75) (see also [`T65229`](https://phabricator.wikimedia.org/T65229)) the HTML tag `<object>` is not compatible with Visual Editor, so the default value for `$iframe` in the `extension.json` file is switched to `true`.
+* Add CSS class `pdf-embed` to the generated (iframe/object) HTML tag.
 * Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@gmail.com>
 
 ## v2.0.2

--- a/PDFEmbed.hooks.php
+++ b/PDFEmbed.hooks.php
@@ -249,6 +249,7 @@ class PDFEmbed
         # check the embed mode and return a proper HTML element
         if ($iframe) {
             return Html::rawElement('iframe', [
+                'class' => 'pdf-embed',
                 'width' => $width,
                 'height' => $height,
                 'src' => $pdfSafeUrl,
@@ -257,9 +258,11 @@ class PDFEmbed
         } else {
             # object mode (default)
             return Html::rawElement('object', [
+                'class' => 'pdf-embed',
                 'width' => $width,
                 'height' => $height,
                 'data' => $pdfSafeUrl,
+                'style' => 'max-width: 100%;',
                 'type' => 'application/pdf'
             ], Html::rawElement(
                 'a',

--- a/PDFEmbed.hooks.php
+++ b/PDFEmbed.hooks.php
@@ -11,6 +11,8 @@
  *
  **/
 
+use MediaWiki\MediaWikiServices;
+
 class PDFEmbed
 {
 
@@ -51,7 +53,7 @@ class PDFEmbed
      */
     static public function removeFilePrefix($filename)
     {
-        $mwServices = MediaWiki\MediaWikiServices::getInstance();
+        $mwServices = MediaWikiServices::getInstance();
         if (method_exists($mwServices, "getContentLanguage")) {
             $contentLang = $mwServices->getContentLanguage();
             # there are four possible prefixes
@@ -102,7 +104,7 @@ class PDFEmbed
         } else {
             // https://www.mediawiki.org/wiki/Manual:UserFactory.php
             $revUserName = $parser->getRevisionUser();
-            $userFactory = MediaWiki\MediaWikiServices::getInstance()->getUserFactory();
+            $userFactory = MediaWikiServices::getInstance()->getUserFactory();
             $user = $userFactory->newFromName($revUserName);
         }
 
@@ -110,7 +112,7 @@ class PDFEmbed
             return self::error('embed_pdf_invalid_user');
         }
 
-        if (!MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')) {
+        if (!MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')) {
             return self::error('embed_pdf_no_permission');
         }
 
@@ -169,7 +171,7 @@ class PDFEmbed
             }
 
             $filename = self::removeFilePrefix($filename);
-            $pdfFile = MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename);
+            $pdfFile = MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename);
 
             if ($pdfFile !== false) {
                 $url = $pdfFile->getFullUrl();

--- a/extension.json
+++ b/extension.json
@@ -1,17 +1,18 @@
 {
 	"name": "PDFEmbed",
-	"version": "2.0.5",
+	"version": "3.0.0",
 	"author": [
-        "[https://www.mediawiki.org/wiki/User:Alexia_E._Smith Alexia E. Smith]",
-        "[http://www.bitplan.com/index.php/Wolfgang_Fahl Wolfgang Fahl/ProfiWiki]",
-        "[http://hexmode.com Mark A. Hershberger]",
-        "[https://clkoerner.com Chris Koerner]"
-    ],
+		"[https://www.mediawiki.org/wiki/User:Alexia_E._Smith Alexia E. Smith]",
+		"[http://www.bitplan.com/index.php/Wolfgang_Fahl Wolfgang Fahl/ProfiWiki]",
+		"[http://hexmode.com Mark A. Hershberger]",
+		"[https://clkoerner.com Chris Koerner]",
+		"[https://github.com/metalevel-tech Spas Z. Spasov]"
+	],
 	"url": "https://www.mediawiki.org/wiki/Extension:PDFEmbed",
 	"descriptionmsg": "pdfembed_description",
 	"license-name": "LGPL-3.0-only",
 	"requires": {
-		"MediaWiki": ">= 1.29.0"
+		"MediaWiki": ">= 1.38.0"
 	},
 	"type": "parserhook",
 	"GroupPermissions": {
@@ -41,7 +42,7 @@
 		"PdfEmbed": {
 			"width": 800,
 			"height": 1090,
-      "iframe": false
+			"iframe": false
 		}
 	},
 	"manifest_version": 1

--- a/extension.json
+++ b/extension.json
@@ -42,7 +42,7 @@
 		"PdfEmbed": {
 			"width": 800,
 			"height": 1090,
-			"iframe": false
+			"iframe": true
 		}
 	},
 	"manifest_version": 1

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Spas.Z.Spasov"
+		]
+	},
+	"pdfembed": "Вграждане на PDF файлове",
+	"pdfembed_description": "Разширение за обработване на PDF файлове.",
+	"embed_pdf_invalid_height": "Невалиден параметър за височина (height) $1.",
+	"embed_pdf_invalid_width": " Невалиден параметър за широчина (width) $1.",
+	"embed_pdf_no_permission": "Нямате права за вграждане на PDF файлове.",
+	"embed_pdf_blank_file": "Адресът (URL) или пътят на PDF файла за вграждане не е зададен.",
+	"embed_pdf_invalid_file": "Адресът (URL) на файла $1 не съществува.",
+	"embed_pdf_invalid_user": "Посочен е невалиден потребител за тестване на разширението за вграждане на PDF файлове.",
+	"right-embed_pdf": "Вграждане на PDF файлове в страници"
+}


### PR DESCRIPTION
Make it fully compatible with MediaWiki 1.38 - deal with all deprecated features:
* Use `RequestContext::getMain()->getUser()` instead of `$wgUser`,
* Use `MediaWiki\MediaWikiServices::getInstance()->getUserFactory()->newFromName($revUserName)` instead of `User::newFromName($revUserName)`,
* Use `MediaWiki\MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($user, 'embed_pdf')` instead of `$user->isAllowed('embed_pdf')`,
* Use `MediaWiki\MediaWikiServices::getInstance()->getRepoGroup()->findFile($filename)` instead of `wfFindFile($filename)`.

Tidy up the code and remove unused function `embedObject()` (note the `embed()` function does this by default).

Bulgarian Translations provided by Spas Z. Spasov <spas.z.spasov@gmail.com>